### PR TITLE
Habilita inspección paralela y modela defectos tardíos en MANUAL/ENJUAGUE/LLENADO

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,4 +1,4 @@
-mport simpy
+import simpy
 import random
 import tkinter as tk
 from tkinter import ttk
@@ -17,8 +17,8 @@ MEDIA_ENTRADA = 32  # AS IS semi automático: llega más demanda de la que el cu
 DESVIACION_ENTRADA = 4
 PROBABILIDAD_BOTELLON_BUENO = 0.95
 PROBABILIDAD_BOTELLON_RETRASO = 0.04  # Botellas aprobadas visualmente, pero detectadas tarde como defectuosas.
-TIEMPO_RETRASO_DEFECTO = 75  # Tiempo perdido promedio por botella defectuosa detectada en proceso.
-LITROS_POR_BOTELLON = 6
+ETAPAS_DETECCION_TARDIA = ("MANUAL", "ENJUAGUE", "LLENADO")
+LITROS_POR_BOTELLON = 7
 
 CAPACIDAD_INSPECCION = 3
 CAPACIDAD_LAVADO_MANUAL = 4
@@ -352,8 +352,6 @@ class EmbotelladoraAsIsGUI:
 
         self.ops_manual = [self.canvas.create_oval(300+i*45-10, y-115, 300+i*45+10, y-95, fill="#2ecc71", outline="#ffffff", width=2) for i in range(CAPACIDAD_LAVADO_MANUAL)]
         self.canvas.create_text(370, y - 130, text=f"Lavado Manual ({CAPACIDAD_LAVADO_MANUAL} Op.)", fill="#959da5", font=("Segoe UI", 8, "bold"))
-        self.canvas.create_text(355, y + 55, text="AS IS: lavado manual\nsin tambor automático", fill="#99aab5", font=("Segoe UI", 8, "bold"))
-
         self.ops_enjuague = [self.canvas.create_oval(540+i*35-10, y-45, 540+i*35+10, y-25, fill="#2ecc71", outline="#ffffff", width=2) for i in range(CAPACIDAD_ENJUAGUE)]
         self.canvas.create_text(595, y - 60, text=f"🚿 Enjuague ({CAPACIDAD_ENJUAGUE} Op.)", fill="#1abc9c", font=("Segoe UI", 8, "bold"))
         self.ops_llenado = [self.canvas.create_oval(750+i*50-10, y-45, 750+i*50+10, y-25, fill="#2ecc71", outline="#ffffff", width=2) for i in range(CAPACIDAD_LLENADO)]
@@ -468,23 +466,33 @@ class EmbotelladoraAsIsGUI:
         while True:
             yield env.timeout(max(1, random.normalvariate(MEDIA_ENTRADA, DESVIACION_ENTRADA)))
             while self.simulacion_pausada: yield env.timeout(0.1)
-            self.total_llegaron += 1
-            id_b += 1
-            env.process(self.flujo_botella(env, id_b))
+            for entrada in range(CAPACIDAD_INSPECCION):
+                self.total_llegaron += 1
+                id_b += 1
+                env.process(self.flujo_botella(env, id_b, entrada))
 
-    def flujo_botella(self, env, id_b):
+    def registrar_defecto_tardio(self, id_b, y, x_descarte, inicio_flujo, litros_merma=0):
+        self.botellas_con_retraso += 1
+        self.tiempo_total_retrasos += max(0, self.env.now - inicio_flujo)
+        if litros_merma:
+            self.mermas_agua += litros_merma
+        self.despachar_movimiento(id_b, x_descarte, y, 150, y + 120)
+
+    def flujo_botella(self, env, id_b, entrada=0):
         y = self.y_faja_ref
         inicio_flujo = env.now
+        x_entrada = 45 + (entrada * 25)
+        etapa_defecto_tardio = random.choice(ETAPAS_DETECCION_TARDIA) if random.random() < PROBABILIDAD_BOTELLON_RETRASO else None
         
-        self.despachar_movimiento(id_b, 20, y, 45, y, estado="CAMINANDO")
+        self.despachar_movimiento(id_b, 20, y, x_entrada, y, estado="CAMINANDO")
         yield env.timeout(2)  
         
         with self.res_inspeccion.request() as req:
             yield req
-            idx_insp = next(i for i in range(CAPACIDAD_INSPECCION) if not self.slots_inspeccion[i])
+            idx_insp = entrada if not self.slots_inspeccion[entrada] else next(i for i in range(CAPACIDAD_INSPECCION) if not self.slots_inspeccion[i])
             self.slots_inspeccion[idx_insp] = True
             x_insp = 45 + (idx_insp * 25)
-            self.despachar_movimiento(id_b, 45, y, x_insp, y, duracion_espera=TIEMPO_INSPECCION, estado="EN_PROCESO", y_proceso=y-15)
+            self.despachar_movimiento(id_b, x_entrada, y, x_insp, y, duracion_espera=TIEMPO_INSPECCION, estado="EN_PROCESO", y_proceso=y-15)
             yield env.timeout(TIEMPO_INSPECCION)
             self.slots_inspeccion[idx_insp] = False
         
@@ -513,6 +521,9 @@ class EmbotelladoraAsIsGUI:
             yield env.timeout(TIEMPO_LAVADO_MANUAL)
             self.slots_manual[idx_op] = False
             self.registrar_tiempo_estacion("MANUAL", inicio_estacion)
+        if etapa_defecto_tardio == "MANUAL":
+            self.registrar_defecto_tardio(id_b, y-70, x_op, inicio_flujo)
+            return
         
         self.despachar_movimiento(id_b, x_op, y-70, 460, y-70)
         yield env.timeout(4)
@@ -535,17 +546,12 @@ class EmbotelladoraAsIsGUI:
             yield env.timeout(TIEMPO_ENJUAGUE)
             self.slots_enjuague[idx_op] = False
             self.registrar_tiempo_estacion("ENJUAGUE", inicio_estacion)
+        if etapa_defecto_tardio == "ENJUAGUE":
+            self.registrar_defecto_tardio(id_b, y, x_op, inicio_flujo)
+            return
             
         self.despachar_movimiento(id_b, x_op, y, 690, y)
         yield env.timeout(4)
-
-        if random.random() < PROBABILIDAD_BOTELLON_RETRASO:
-            self.botellas_con_retraso += 1
-            self.tiempo_total_retrasos += TIEMPO_RETRASO_DEFECTO
-            self.despachar_movimiento(id_b, 690, y, 690, y + 55, duracion_espera=TIEMPO_RETRASO_DEFECTO, estado="EN_PROCESO", y_proceso=y + 45)
-            yield env.timeout(TIEMPO_RETRASO_DEFECTO)
-            self.despachar_movimiento(id_b, 690, y + 55, 150, y + 120)
-            return
 
         self.despachar_movimiento(id_b, 690, y, 670, y, estado="CAMINANDO", canal_cola="LLENADO")
         yield env.timeout(3)
@@ -558,11 +564,19 @@ class EmbotelladoraAsIsGUI:
             idx_op = next(i for i in range(CAPACIDAD_LLENADO) if not self.slots_llenado[i])
             self.slots_llenado[idx_op] = True
             x_op = 750 + (idx_op * 50)
+            if etapa_defecto_tardio == "LLENADO":
+                tiempo_hasta_fuga = random.uniform(1, TIEMPO_LLENADO)
+                litros_perdidos = max(1, min(LITROS_POR_BOTELLON, round((tiempo_hasta_fuga / TIEMPO_LLENADO) * LITROS_POR_BOTELLON)))
+                self.despachar_movimiento(id_b, 670, y, x_op, y, duracion_espera=tiempo_hasta_fuga, estado="EN_PROCESO", y_proceso=y-15)
+                yield env.timeout(tiempo_hasta_fuga)
+                self.slots_llenado[idx_op] = False
+                self.registrar_tiempo_estacion("LLENADO", inicio_estacion)
+                self.registrar_defecto_tardio(id_b, y, x_op, inicio_flujo, litros_perdidos)
+                return
             self.despachar_movimiento(id_b, 670, y, x_op, y, duracion_espera=TIEMPO_LLENADO, estado="EN_PROCESO", y_proceso=y-15)
             yield env.timeout(TIEMPO_LLENADO)
             self.slots_llenado[idx_op] = False
             self.registrar_tiempo_estacion("LLENADO", inicio_estacion)
-            if random.random() < 0.002: self.mermas_agua += LITROS_POR_BOTELLON; return
             
         self.despachar_movimiento(id_b, x_op, y, 850, y)
         yield env.timeout(4)


### PR DESCRIPTION
### Motivation
- Permitir que los 3 inspectores trabajen en paralelo desde 3 puntos de entrada y evitar que solo uno procese todas las llegadas. 
- Modelar defectos detectados tardíamente en puntos intermedios (lavado manual, enjuague, llenado) que generan tiempo perdido y, en caso de fuga durante llenado, merma de agua.
- Ajustar parámetros del modelo para reflejar botellones de 7 litros y eliminar un texto visual solicitado en la interfaz.

### Description
- Corrige el import inicial (`mport simpy` → `import simpy`) y cambia `LITROS_POR_BOTELLON` a 7; añade `ETAPAS_DETECCION_TARDIA = ("MANUAL","ENJUAGUE","LLENADO")` para controlar dónde puede detectarse un defecto tardío. 
- Cambia `generador_botellas` para generar un lote de `CAPACIDAD_INSPECCION` botellones por llegada y pasa un parámetro `entrada` a `flujo_botella` para representar las 3 entradas/inspectores en paralelo. 
- Añade `registrar_defecto_tardio` que acumula `botellas_con_retraso`, suma tiempo perdido desde el inicio del flujo y añade merma cuando corresponde, y actualiza la animación para descartar la botella. 
- Modifica `flujo_botella` para respetar la entrada/slot de inspección, seleccionar aleatoriamente (con `PROBABILIDAD_BOTELLON_RETRASO`) una etapa de detección tardía entre `MANUAL`, `ENJUAGUE` y `LLENADO`, y manejar: detección después de `MANUAL` y `ENJUAGUE` (descarta tras consumir el tiempo de estación) y detección durante `LLENADO` (simula tiempo hasta fuga, calcula litros perdidos proporcionalmente y registra la merma y el descarte). 
- Elimina la cadena de texto visual debajo del lavado manual solicitada por el cambio de interfaz.

### Testing
- Se ejecutó `python -m py_compile app.py` y la compilación fue exitosa. 
- Se ejecutó `git diff --check` y no se detectaron problemas en el diff. 
- Se intentó una ejecución de simulación headless en el entorno de CI local, pero falló porque la dependencia `simpy` no está instalada en este entorno (por tanto no se ejecutó la simulación completa aquí).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a38e5fd84048327b968e497a2582517)